### PR TITLE
feat: Add Custom App-Node Interface, Lib Functions, and UI Components for React-Flow Integration

### DIFF
--- a/app/workflow/_components/FlowEditor.tsx
+++ b/app/workflow/_components/FlowEditor.tsx
@@ -11,13 +11,22 @@ import {
   useNodesState,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { CreateFlowNode } from "@/lib/workflow/createFlowNode";
+import { TaskType } from "@/types/task.types";
+import NodeComponent from "./node/NodeComponent";
 
 type Props = {
   workflow: Workflow;
 };
 
+const nodeTypes = {
+  WebextractNode: NodeComponent
+}
+
 const FlowEditor = ({ workflow }: Props) => {
-  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState([
+    CreateFlowNode(TaskType.LAUNCH_BROWSER)
+  ]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   return (
@@ -27,6 +36,7 @@ const FlowEditor = ({ workflow }: Props) => {
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
       >
         <Background />
         <Controls position="bottom-left" />

--- a/app/workflow/_components/node/NodeCard.tsx
+++ b/app/workflow/_components/node/NodeCard.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import React from "react";
+
+type Props = {
+  nodeId: string;
+  children: React.ReactNode;
+};
+
+const NodeCard = ({ nodeId, children }: Props) => {
+  return <div>{children}</div>;
+};
+
+export default NodeCard;

--- a/app/workflow/_components/node/NodeComponent.tsx
+++ b/app/workflow/_components/node/NodeComponent.tsx
@@ -1,0 +1,10 @@
+import { NodeProps } from "@xyflow/react";
+import { memo } from "react";
+import NodeCard from "./NodeCard";
+
+const NodeComponent = memo((props: NodeProps) => {
+  return <NodeCard nodeId={props.id}>AppNode</NodeCard>;
+});
+
+export default NodeComponent;
+NodeComponent.displayName = "NodeComponent"

--- a/lib/workflow/createFlowNode.ts
+++ b/lib/workflow/createFlowNode.ts
@@ -1,0 +1,17 @@
+import { TaskType } from "@/types/task.types";
+
+export function CreateFlowNode(
+  nodeType: TaskType,
+  position?: { x: number; y: number }
+) {
+  return {
+    //these are properties which are required for react-flow
+    id: crypto.randomUUID(),
+    type: "WebextractNode",
+    data: {
+      type: nodeType,
+      inputs: {},
+    },
+    position: position ?? { x: 0, y: 0 },
+  };
+}

--- a/lib/workflow/task/LaunchBrowser.tsx
+++ b/lib/workflow/task/LaunchBrowser.tsx
@@ -1,0 +1,11 @@
+import { TaskType } from "@/types/task.types";
+import { Globe, LucideProps } from "lucide-react";
+
+export const LaunchBrowserTask = {
+  type: TaskType.LAUNCH_BROWSER,
+  label: "Launch browser",
+  icon: (props: LucideProps) => (
+    <Globe className="stroke-pink-500" {...props} />
+  ),
+  isEntryPoint: true,
+};

--- a/lib/workflow/task/registry.tsx
+++ b/lib/workflow/task/registry.tsx
@@ -1,0 +1,5 @@
+import { LaunchBrowserTask } from "./LaunchBrowser";
+
+export const TaskRegistry = {
+  LAUNCH_BROWSER: LaunchBrowserTask,
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{ts,tsx}",
   ],
   theme: {
     container: {

--- a/types/appNode.types.ts
+++ b/types/appNode.types.ts
@@ -1,0 +1,12 @@
+import { Node } from "@xyflow/react";
+import { TaskType } from "./task.types";
+
+export interface IAppNodeData {
+  type: TaskType;
+  inputs: Record<string, string>;
+  [key: string]: any;
+}
+
+export interface IAppNode extends Node {
+  data: IAppNodeData
+}

--- a/types/task.types.ts
+++ b/types/task.types.ts
@@ -1,0 +1,3 @@
+export enum TaskType {
+  "LAUNCH_BROWSER",
+}


### PR DESCRIPTION
This PR introduces a custom `app-node` interface that extends the `Node` interface from `react-flow`. It also adds several utility functions and UI components to support rendering nodes on the canvas with additional properties.

1. **Custom App-Node Interface**:
   - Added a custom `app-node` interface that extends the `Node` interface from `react-flow`.
   - Included additional properties required for rendering nodes in the application.

2. **Lib Functions**:
   - Added a `LaunchBrowserTask` object with properties like `label`, `type`, `icon`, etc., required for rendering an `app-node`.
   - Introduced a registry function that exports an object containing the label and required properties for a specific node.

3. **UI Components**:
   - Added components to render node properties on the canvas.
   - Configured `tailwind.config.js` to support content in the `./lib` folder.

4. **Temporary NodeTypes**:
   - Added temporary `nodeTypes` for `ReactFlow` to facilitate initial rendering of nodes.