### PR TITLE
feat: add node zoom when double clicked

### DIFF
--- a/app/workflow/_components/node/NodeCard.tsx
+++ b/app/workflow/_components/node/NodeCard.tsx
@@ -1,14 +1,42 @@
-"use client"
+"use client";
 
+import { cn } from "@/lib/utils";
+import { useReactFlow } from "@xyflow/react";
 import React from "react";
 
 type Props = {
   nodeId: string;
   children: React.ReactNode;
+  isSelected: boolean;
 };
 
-const NodeCard = ({ nodeId, children }: Props) => {
-  return <div>{children}</div>;
+const NodeCard = ({ nodeId, children, isSelected }: Props) => {
+  const { getNode, setCenter } = useReactFlow();
+
+  return (
+    <div
+      onDoubleClick={() => {
+        const node = getNode(nodeId);
+        if (!node) return;
+        const { position, measured } = node;
+        if (!position || !measured) return;
+        const { width, height } = measured;
+        const x = position.x + width! / 2;
+        const y = position.y + height! / 2;
+        if (x === undefined || y === undefined) return;
+        setCenter(x, y, {
+          zoom: 1,
+          duration: 500,
+        });
+      }}
+      className={cn(
+        "w-[420px] border-2 border-separate bg-background p-2 rounded-md cursor-pointer text-xs gap-1 flex flex-col",
+        isSelected && "border-primary"
+      )}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default NodeCard;

--- a/app/workflow/_components/node/NodeComponent.tsx
+++ b/app/workflow/_components/node/NodeComponent.tsx
@@ -3,8 +3,12 @@ import { memo } from "react";
 import NodeCard from "./NodeCard";
 
 const NodeComponent = memo((props: NodeProps) => {
-  return <NodeCard nodeId={props.id}>AppNode</NodeCard>;
+  return (
+    <NodeCard nodeId={props.id} isSelected={!!props.selected}>
+      AppNode
+    </NodeCard>
+  );
 });
 
 export default NodeComponent;
-NodeComponent.displayName = "NodeComponent"
+NodeComponent.displayName = "NodeComponent";


### PR DESCRIPTION
This PR introduces a new feature to the NodeCard component that allows users to center the view on a specific node when double-clicking the card. The changes include:

1. Double-Click Handler:
- Added an onDoubleClick event handler to the NodeCard component.
- When the card is double-clicked, the viewport is centered on the corresponding node.

2. Node Positioning:
- The getNode method from useReactFlow is used to retrieve the node’s position and dimensions.
- The center of the node is calculated using its position and measured properties.

https://github.com/user-attachments/assets/bf17d510-c9e6-41a1-ae4d-d8dd40ec58d7

